### PR TITLE
Properly check if model instance's pk is set

### DIFF
--- a/tastypie/validation.py
+++ b/tastypie/validation.py
@@ -51,7 +51,7 @@ class FormValidation(Validation):
 
         kwargs = {'data': {}}
 
-        if hasattr(bundle.obj, 'pk'):
+        if hasattr(bundle.obj, 'pk') and bundle.obj.pk:
             if issubclass(self.form_class, ModelForm):
                 kwargs['instance'] = bundle.obj
 


### PR DESCRIPTION
FormValidation is checking presence of pk attibute to determine if we are editing an existing model instance.
As per
 https://docs.djangoproject.com/en/dev/ref/models/instances/?from=olddocs#how-django-knows-to-update-vs-insert
One should check if obj.pk evaluates to True.
