### PR TITLE
Reduce ApiKey key length to 128

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ except ImportError:
 
 setup(
     name='django-tastypie',
-    version='0.9.12-wave3',
+    version='0.9.12-wave4',
     description='A flexible & capable API layer for Django.',
     author='Daniel Lindsley',
     author_email='daniel@toastdriven.com',

--- a/tastypie/migrations/0001_initial.py
+++ b/tastypie/migrations/0001_initial.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
             name='ApiKey',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('key', models.CharField(default=b'', max_length=256, db_index=True, blank=True)),
+                ('key', models.CharField(default=b'', max_length=128, db_index=True, blank=True)),
                 ('created', models.DateTimeField(default=tastypie.utils.timezone.now)),
                 ('user', models.OneToOneField(related_name='api_key', to=settings.AUTH_USER_MODEL)),
             ],

--- a/tastypie/models.py
+++ b/tastypie/models.py
@@ -32,7 +32,7 @@ if 'django.contrib.auth' in settings.INSTALLED_APPS:
     
     class ApiKey(models.Model):
         user = models.OneToOneField(User, related_name='api_key')
-        key = models.CharField(max_length=256, blank=True, default='', db_index=True)
+        key = models.CharField(max_length=128, blank=True, default='', db_index=True)
         created = models.DateTimeField(default=now)
 
         def __unicode__(self):

--- a/tastypie/south_migrations/0001_initial.py
+++ b/tastypie/south_migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(SchemaMigration):
         db.create_table('tastypie_apikey', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('user', self.gf('django.db.models.fields.related.OneToOneField')(related_name='api_key', unique=True, to=orm['auth.User'])),
-            ('key', self.gf('django.db.models.fields.CharField')(default='', max_length=256, blank=True)),
+            ('key', self.gf('django.db.models.fields.CharField')(default='', max_length=128, blank=True)),
             ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
         ))
         db.send_create_signal('tastypie', ['ApiKey'])
@@ -87,7 +87,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'ApiKey'},
             'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'blank': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'blank': 'True'}),
             'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'api_key'", 'unique': 'True', 'to': "orm['auth.User']"})
         }
     }

--- a/tastypie/south_migrations/0002_add_apikey_index.py
+++ b/tastypie/south_migrations/0002_add_apikey_index.py
@@ -66,7 +66,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'ApiKey'},
             'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2012, 11, 5, 0, 0)'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
-            'key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '256', 'db_index': 'True', 'blank': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'default': "''", 'max_length': '128', 'db_index': 'True', 'blank': 'True'}),
             'user': ('django.db.models.fields.related.OneToOneField', [], {'related_name': "'api_key'", 'unique': 'True', 'to': "orm['auth.User']"})
         }
     }


### PR DESCRIPTION
This is a port from upstream.

This avoids issues with MySQL where multi-byte encodings will cause a
256-character field to exceed the maximum index length (767 bytes).
